### PR TITLE
executables like `sudo` in NixOS come from `/run/wrappers/bin`

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -55,7 +55,7 @@
       enable = true;
       initExtra = ''
         # Make Nix and home-manager installed things available in PATH.
-        export PATH=/run/current-system/sw/bin/:/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:$PATH
+        export PATH=/run/wrappers/bin:/run/current-system/sw/bin/:/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:$PATH
       '';
     };
 
@@ -64,7 +64,7 @@
       enable = true;
       envExtra = ''
         # Make Nix and home-manager installed things available in PATH.
-        export PATH=/run/current-system/sw/bin/:/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:$PATH
+        export PATH=/run/wrappers/bin:/run/current-system/sw/bin/:/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:/etc/profiles/per-user/$USER/bin:$PATH
       '';
     };
 


### PR DESCRIPTION
If not present, sudo command will fail to run in NixOS if someone is sharing this configuration across NixOS, macOS and other linux distro.

This is on my NixOS:
```sh
shivaraj in 🌐 nixos in nix-dev-home on  export-wrappers-path
❯ which sudo
/run/wrappers/bin/sudo
```