### PR TITLE
template: Fix misleading file comment

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,4 @@
-# This is your nix-darwin configuration.
+# This is your nixos configuration.
 # For home configuration, see /modules/home/*
 { flake, pkgs, lib, ... }:
 


### PR DESCRIPTION
Change misleading `nix-darwin configuration` comment in `modules/nixos/default.nix`.