### PR TITLE
readme: update troubleshooting related to ca-certificates on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ By default, [home-manager] is configured to run garbage collection automatically
 
 **Solution**: This is an instance of https://github.com/nix-community/home-manager/issues/4611. Run `sudo mkdir /nix/var/nix/profiles/per-user/$(whoami)/ && sudo chown $(whoami) /nix/var/nix/profiles/per-user/$(whoami)` and try again.
 
-### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)
+### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
 
 **Problem**: While initialising template on MacOS, if it shows error like: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)
 **Solution**: Run below commands to resolve

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ By default, [home-manager] is configured to run garbage collection automatically
 
 ### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
 
-**Problem**: While initialising template on MacOS, if it shows error like: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)
+**Problem**: While initialising template on MacOS, if it shows error like: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
+
 **Solution**: Run below commands to resolve
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -133,11 +133,14 @@ By default, [home-manager] is configured to run garbage collection automatically
 
 ### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
 
-**Problem**: While initialising template on MacOS, if it shows error like: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
+**Problem**: On macOS, you may see this error: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
 
-**Solution**: Run below commands to resolve
+**Solution**: You may be able to resolve this by running:
 
 ```sh
 sudo rm /etc/ssl/certs/ca-certificates.crt
 sudo ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 ```
+
+See https://github.com/NixOS/nix/issues/2899#issuecomment-1669501326
+

--- a/README.md
+++ b/README.md
@@ -130,3 +130,13 @@ By default, [home-manager] is configured to run garbage collection automatically
 **Problem**: When using home-manager, `nix run` shows an error like: `error: opening lock file '/nix/var/nix/profiles/per-user/utkarsh.pandey1/profile.lock': No such file or directory`
 
 **Solution**: This is an instance of https://github.com/nix-community/home-manager/issues/4611. Run `sudo mkdir /nix/var/nix/profiles/per-user/$(whoami)/ && sudo chown $(whoami) /nix/var/nix/profiles/per-user/$(whoami)` and try again.
+
+### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)
+
+**Problem**: While initialising template on MacOS, if it shows error like: `error: unable to download ... Problem with the SSL CA cert (path? access rights?)
+**Solution**: Run below commands to resolve
+
+```sh
+sudo rm /etc/ssl/certs/ca-certificates.crt
+sudo ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+```


### PR DESCRIPTION
Add troubleshooting doc for ca-ceritificates on MacOS while initialising the template.