### PR TITLE
refactor: prefer id over whoami

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you are on macOS or running other Linux distros:
 1. [Install Nix](https://nixos.asia/en/install):
     ```sh-session
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
-      sh -s -- install --no-confirm --extra-conf "trusted-users = $(whoami)"
+      sh -s -- install --no-confirm --extra-conf "trusted-users = $(id -un)"
     ```
 1. Open a new terminal; Initialize[^omnix] your Nix configuration using this repo as template:
     ```sh-session
@@ -128,7 +128,7 @@ By default, [home-manager] is configured to run garbage collection automatically
 
 **Problem**: When using home-manager, `nix run` shows an error like: `error: opening lock file '/nix/var/nix/profiles/per-user/utkarsh.pandey1/profile.lock': No such file or directory`
 
-**Solution**: This is an instance of https://github.com/nix-community/home-manager/issues/4611. Run `sudo mkdir /nix/var/nix/profiles/per-user/$(whoami)/ && sudo chown $(whoami) /nix/var/nix/profiles/per-user/$(whoami)` and try again.
+**Solution**: This is an instance of https://github.com/nix-community/home-manager/issues/4611. Run `sudo mkdir /nix/var/nix/profiles/per-user/$(id -un)/ && sudo chown $(id -un) /nix/var/nix/profiles/per-user/$(id -un)` and try again.
 
 ### `error: unable to download ... Problem with the SSL CA cert (path? access rights?)`
 

--- a/modules/flake-parts/template.nix
+++ b/modules/flake-parts/template.nix
@@ -114,7 +114,7 @@
         params = [
           {
             name = "username";
-            description = "Your username as shown by `whoami`";
+            description = "Your username as shown by `id -un`";
             placeholder = "runner";
           }
           # Git


### PR DESCRIPTION
Replace `whoami` with `id -un` for broader compatibility, as `id -un` is POSIX-compliant, widely available, and reliable. It produces the same output as `whoami` across environments without issues.

## References
- [`id`](https://linux.die.net/man/1/id)
- [`whoami`](https://linux.die.net/man/1/whoami)

---

Edit 1:
Main source: [Linux `whoami` command and the `id` command of its successor](https://www.programmersought.com/article/94903654222/)

> The id command of whoami ’s replacement is defined by the POSIX standard, and the implementation is done by various operating system vendors.
> Because the POSIX standard is a member of the IEEE standard, the id command is more standardized than the whoami command as a product of standardization, and as long as the operating system supports the POSIX standard, there will be an id command. Therefore, in daily operations, using the standardized id command is more recommended.