### PR TITLE
darwin/hm: Automatically move old dotfiles out of the way

### DIFF
--- a/configurations/darwin/example.nix
+++ b/configurations/darwin/example.nix
@@ -20,7 +20,7 @@ in
 
   home-manager = {
     # Automatically move old dotfiles out of the way
-    home-manager.backupFileExtension = "bak";
+    backupFileExtension = "bak";
 
     # Enable home-manager for "runner" user
     users."runner" = {

--- a/configurations/darwin/example.nix
+++ b/configurations/darwin/example.nix
@@ -18,9 +18,14 @@ in
   # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
   users.users."runner".home = "/Users/runner";
 
-  # Enable home-manager for "runner" user
-  home-manager.users."runner" = {
-    imports = [ (self + /configurations/home/runner.nix) ];
+  home-manager = {
+    # Automatically move old dotfiles out of the way
+    home-manager.backupFileExtension = "bak";
+
+    # Enable home-manager for "runner" user
+    users."runner" = {
+      imports = [ (self + /configurations/home/runner.nix) ];
+    };
   };
 
   # Used for backwards compatibility, please read the changelog before changing.

--- a/configurations/darwin/example.nix
+++ b/configurations/darwin/example.nix
@@ -20,7 +20,11 @@ in
 
   home-manager = {
     # Automatically move old dotfiles out of the way
-    backupFileExtension = "bak";
+    #
+    # Note that home-manager is not very smart, if this backup file already exists it 
+    # will complain "Existing file .. would be clobbered by backing up". To mitigate this,
+    # we try to use as unique a backup file extension as possible.
+    backupFileExtension = "nixos-unified-template-backup";
 
     # Enable home-manager for "runner" user
     users."runner" = {


### PR DESCRIPTION
It makes sense to do this because often people already have old dotfiles in the way.

For https://github.com/juspay/nixone/issues/6

- [x] Test that it actually works