### PR TITLE
home-manager: Allow changing `nix` version via `nixpkgs` revision update

### DIFF
--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -1,4 +1,4 @@
-{ flake, pkgs, lib, ... }:
+{ flake, pkgs, lib, config, ... }:
 let
   inherit (flake) inputs;
   inherit (inputs) self;

--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -7,6 +7,10 @@ in
   imports = [
     self.homeModules.default
   ];
+  # To use the `nix` from `inputs.nixpkgs` on templates using the standalone `home-manager` template
+  home.packages = [
+    config.nix.package
+  ];
   home.username = "runner";
   home.homeDirectory = lib.mkDefault "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/runner";
   home.stateVersion = "24.11";

--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -7,10 +7,15 @@ in
   imports = [
     self.homeModules.default
   ];
+
   # To use the `nix` from `inputs.nixpkgs` on templates using the standalone `home-manager` template
+
+  # `nix.package` is already set if on `NixOS` or `nix-darwin`.
+  nix.package = lib.mkForce pkgs.nix;
   home.packages = [
     config.nix.package
   ];
+
   home.username = "runner";
   home.homeDirectory = lib.mkDefault "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/runner";
   home.stateVersion = "24.11";

--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -11,7 +11,7 @@ in
   # To use the `nix` from `inputs.nixpkgs` on templates using the standalone `home-manager` template
 
   # `nix.package` is already set if on `NixOS` or `nix-darwin`.
-  nix.package = lib.mkForce pkgs.nix;
+  nix.package = lib.mkDefault pkgs.nix;
   home.packages = [
     config.nix.package
   ];

--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -11,6 +11,7 @@ in
   # To use the `nix` from `inputs.nixpkgs` on templates using the standalone `home-manager` template
 
   # `nix.package` is already set if on `NixOS` or `nix-darwin`.
+  # TODO: Avoid setting `nix.package` in two places. Does https://github.com/juspay/nixos-unified-template/issues/93 help here?
   nix.package = lib.mkDefault pkgs.nix;
   home.packages = [
     config.nix.package


### PR DESCRIPTION
Tested standalone `home-manager` template on:
- [x] Ubuntu