### PR TITLE
Allow multiple users in `config` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Global configuration is in the `./config.nix` file. Here, you can specify your u
 
 ## What's included
 
-Here we describe just a handful of tools included in this template. See the [./modules](./modules) directory for more.
+Here we describe just a handful of tools included in this template. See the [./modules](./modules) directory for more. All of `./modules` and `./configurations` directories are organized by [nixos-unified's autowiring structure](https://nixos-unified.org/autowiring.html).
 
 ### neovim
 

--- a/configurations/darwin/example.nix
+++ b/configurations/darwin/example.nix
@@ -14,29 +14,12 @@ in
   nixpkgs.hostPlatform = "aarch64-darwin";
   networking.hostName = "example";
 
-  # For home-manager to work.
-  # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-  users.users = lib.mapAttrs
-    (_: v: {
-      home = "/Users/${v.username}";
-    })
-    flake.config.users;
-
-  home-manager = {
-    # Automatically move old dotfiles out of the way
-    #
-    # Note that home-manager is not very smart, if this backup file already exists it
-    # will complain "Existing file .. would be clobbered by backing up". To mitigate this,
-    # we try to use as unique a backup file extension as possible.
-    backupFileExtension = "nixos-unified-template-backup";
-
-    # Enable home-manager for our users
-    users = lib.mapAttrs
-      (_: v: {
-        imports = [ (self + /configurations/home/${v.username}.nix) ];
-      })
-      flake.config.users;
-  };
+  # Automatically move old dotfiles out of the way
+  #
+  # Note that home-manager is not very smart, if this backup file already exists it
+  # will complain "Existing file .. would be clobbered by backing up". To mitigate this,
+  # we try to use as unique a backup file extension as possible.
+  home-manager.backupFileExtension = "nixos-unified-template-backup";
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog

--- a/configurations/darwin/example.nix
+++ b/configurations/darwin/example.nix
@@ -1,11 +1,10 @@
 # See /modules/darwin/* for actual settings
 # This file is just *top-level* configuration.
-{ flake, ... }:
+{ flake, lib, ... }:
 
 let
   inherit (flake) inputs;
   inherit (inputs) self;
-  inherit (flake.config) me;
 in
 {
   imports = [
@@ -17,7 +16,11 @@ in
 
   # For home-manager to work.
   # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-  users.users."${me.username}".home = "/Users/${me.username}";
+  users.users = lib.mapAttrs
+    (_: v: {
+      home = "/Users/${v.username}";
+    })
+    flake.config.users;
 
   home-manager = {
     # Automatically move old dotfiles out of the way
@@ -27,10 +30,12 @@ in
     # we try to use as unique a backup file extension as possible.
     backupFileExtension = "nixos-unified-template-backup";
 
-    # Enable home-manager for our user
-    users."${me.username}" = {
-      imports = [ (self + /configurations/home/${me.username}.nix) ];
-    };
+    # Enable home-manager for our users
+    users = lib.mapAttrs
+      (_: v: {
+        imports = [ (self + /configurations/home/${v.username}.nix) ];
+      })
+      flake.config.users;
   };
 
   # Used for backwards compatibility, please read the changelog before changing.

--- a/configurations/home/runner.nix
+++ b/configurations/home/runner.nix
@@ -2,7 +2,7 @@
 let
   inherit (flake) inputs;
   inherit (inputs) self;
-  inherit (flake.config) me;
+  me = flake.config.users."runner";
 in
 {
   imports = [

--- a/configurations/nixos/example/configuration.nix
+++ b/configurations/nixos/example/configuration.nix
@@ -1,8 +1,4 @@
 # NOTE: We expect this file to be supplanted by the original /etc/nixos/configuration.nix
-{ flake, ... }:
-let
-  inherit (flake.config) me;
-in
 {
   # These are normally in hardware-configuration.nix
   boot.loader.grub.device = "nodev";
@@ -10,10 +6,6 @@ in
 
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "example";
-
-  # For home-manager to work.
-  # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-  users.users."${me.username}".isNormalUser = true;
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog

--- a/configurations/nixos/example/default.nix
+++ b/configurations/nixos/example/default.nix
@@ -1,6 +1,6 @@
 # See /modules/nixos/* for actual settings
 # This file is just *top-level* configuration.
-{ flake, lib, ... }:
+{ flake, ... }:
 
 let
   inherit (flake) inputs;
@@ -12,19 +12,4 @@ in
     self.nixosModules.gui
     ./configuration.nix
   ];
-
-  # For home-manager to work.
-  # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-  users.users = lib.mapAttrs
-    (_: _: {
-      isNormalUser = true;
-    })
-    flake.config.users;
-
-  # Enable home-manager for our user
-  home-manager.users = lib.mapAttrs
-    (_: v: {
-      imports = [ (self + /configurations/home/${v.username}.nix) ];
-    })
-    flake.config.users;
 }

--- a/configurations/nixos/example/default.nix
+++ b/configurations/nixos/example/default.nix
@@ -1,11 +1,10 @@
 # See /modules/nixos/* for actual settings
 # This file is just *top-level* configuration.
-{ flake, ... }:
+{ flake, lib, ... }:
 
 let
   inherit (flake) inputs;
   inherit (inputs) self;
-  inherit (flake.config) me;
 in
 {
   imports = [
@@ -14,8 +13,18 @@ in
     ./configuration.nix
   ];
 
+  # For home-manager to work.
+  # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
+  users.users = lib.mapAttrs
+    (_: _: {
+      isNormalUser = true;
+    })
+    flake.config.users;
+
   # Enable home-manager for our user
-  home-manager.users."${me.username}" = {
-    imports = [ (self + /configurations/home/${me.username}.nix) ];
-  };
+  home-manager.users = lib.mapAttrs
+    (_: v: {
+      imports = [ (self + /configurations/home/${v.username}.nix) ];
+    })
+    flake.config.users;
 }

--- a/modules/darwin/common
+++ b/modules/darwin/common
@@ -1,0 +1,1 @@
+../nixos/common

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,15 +1,14 @@
 # This is your nix-darwin configuration.
 # For home configuration, see /modules/home/*
-{ flake, pkgs, lib, ... }:
+{ flake, ... }:
 
 {
+  imports = [
+    flake.inputs.self.nixosModules.common
+  ];
+
   # Use TouchID for `sudo` authentication
   security.pam.services.sudo_local.touchIdAuth = true;
-
-  # These users can add Nix caches.
-  nix.settings.trusted-users = [
-    "root"
-  ] ++ lib.mapAttrsToList (_: v: v.username) flake.config.users;
 
   # Configure macOS system
   # More examples => https://github.com/ryan4yin/nix-darwin-kickstarter/blob/main/rich-demo/modules/system.nix

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -1,10 +1,8 @@
 # This is your nix-darwin configuration.
 # For home configuration, see /modules/home/*
-{ flake, ... }:
-
 {
   imports = [
-    flake.inputs.self.nixosModules.common
+    ./common
   ];
 
   # Use TouchID for `sudo` authentication

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -2,17 +2,14 @@
 # For home configuration, see /modules/home/*
 { flake, pkgs, lib, ... }:
 
-let
-  inherit (flake) inputs;
-  inherit (inputs) self;
-  inherit (flake.config) me;
-in
 {
   # Use TouchID for `sudo` authentication
   security.pam.services.sudo_local.touchIdAuth = true;
 
   # These users can add Nix caches.
-  nix.settings.trusted-users = [ "root" me.username ];
+  nix.settings.trusted-users = [
+    "root"
+  ] ++ lib.mapAttrsToList (_: v: v.username) flake.config.users;
 
   # Configure macOS system
   # More examples => https://github.com/ryan4yin/nix-darwin-kickstarter/blob/main/rich-demo/modules/system.nix

--- a/modules/flake/config-module.nix
+++ b/modules/flake/config-module.nix
@@ -1,13 +1,16 @@
 { lib, ... }:
 {
   options = {
-    me = lib.mkOption {
+    users = lib.mkOption {
       default = { };
-      type = lib.types.submodule {
+      description = "All available users";
+      type = lib.types.attrsOf (lib.types.submodule ({ name, ... }: {
         options = {
           username = lib.mkOption {
             type = lib.types.str;
             description = "Your username as shown by `id -un`";
+            default = name;
+            defaultText = "By default, this is the attrset key.";
           };
           fullname = lib.mkOption {
             type = lib.types.str;
@@ -18,7 +21,7 @@
             description = "Your email for use in Git config";
           };
         };
-      };
+      }));
     };
   };
 }

--- a/modules/flake/config.nix
+++ b/modules/flake/config.nix
@@ -1,10 +1,11 @@
 # Global configuration for this repo
 #
-# See ./modules/flake-parts/config-module.nix for schema
+# See ./modules/flake/config-module.nix for schema
 {
-  me = {
-    username = "runner";
-    fullname = "John Doe";
-    email = "johndoe@example.com";
+  users = {
+    runner = {
+      fullname = "John Doe";
+      email = "johndoe@example.com";
+    };
   };
 }

--- a/modules/flake/template.nix
+++ b/modules/flake/template.nix
@@ -16,7 +16,7 @@
             || hasInfix "modules/darwin" path;
           nixosOnly =
             hasInfix "configurations/nixos" path
-            || hasInfix "modules/nixos" path;
+            || (hasInfix "modules/nixos/" path && !hasInfix "modules/nixos/common" path);
           alwaysExclude =
             hasSuffix "LICENSE" path
             || hasSuffix "README.md" path

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -1,6 +1,6 @@
-{ flake, ... }:
+{ config, flake, ... }:
 let
-  inherit (flake.config) me;
+  me = flake.config.users.${config.home.username};
 in
 {
   home.shellAliases = {

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -1,0 +1,6 @@
+# Configuration common to NixOS and darwin
+{
+  imports = [
+    ./trust-everyone.nix
+  ];
+}

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -2,5 +2,6 @@
 {
   imports = [
     ./trust-everyone.nix
+    ./home-manager.nix
   ];
 }

--- a/modules/nixos/common/home-manager.nix
+++ b/modules/nixos/common/home-manager.nix
@@ -1,0 +1,25 @@
+# Enable home-manager for all users
+{ flake, pkgs, lib, ... }:
+
+let
+  inherit (flake) inputs;
+  inherit (inputs) self;
+in
+{
+  # For home-manager to work.
+  # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
+  users.users = lib.mapAttrs
+    (_: v: {
+      home = "/Users/${v.username}";
+    } // lib.optionalAttrs pkgs.stdenv.isLinux {
+      isNormalUser = true;
+    })
+    flake.config.users;
+
+  # Enable home-manager for our user
+  home-manager.users = lib.mapAttrs
+    (_: v: {
+      imports = [ (self + /configurations/home/${v.username}.nix) ];
+    })
+    flake.config.users;
+}

--- a/modules/nixos/common/trust-everyone.nix
+++ b/modules/nixos/common/trust-everyone.nix
@@ -1,0 +1,8 @@
+{ flake, lib, ... }:
+
+{
+  # All users can add Nix caches.
+  nix.settings.trusted-users = [
+    "root"
+  ] ++ lib.mapAttrsToList (_: v: v.username) flake.config.users;
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,15 +1,12 @@
 # This is your nixos configuration.
 # For home configuration, see /modules/home/*
-{ flake, pkgs, lib, ... }:
+{ flake, lib, ... }:
 
-let
-  inherit (flake) inputs;
-  inherit (inputs) self;
-  inherit (flake.config) me;
-in
 {
   # These users can add Nix caches.
-  nix.settings.trusted-users = [ "root" me.username ];
+  nix.settings.trusted-users = [
+    "root"
+  ] ++ lib.mapAttrsToList (_: v: v.username) flake.config.users;
 
   services.openssh.enable = true;
 }

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,12 +1,9 @@
 # This is your nixos configuration.
 # For home configuration, see /modules/home/*
-{ flake, lib, ... }:
-
+{ flake, ... }:
 {
-  # These users can add Nix caches.
-  nix.settings.trusted-users = [
-    "root"
-  ] ++ lib.mapAttrsToList (_: v: v.username) flake.config.users;
-
+  imports = [
+    flake.inputs.self.nixosModules.common
+  ];
   services.openssh.enable = true;
 }


### PR DESCRIPTION
Note: these don't _yet_ automatically scaffold multiple users (#134). That will be done in separate PR. This PR just gets rid of the `config.me` hardcoding which stands in the way of #134.