### PR TITLE
nixos: One-click install via disko-install

### DIFF
--- a/configurations/nixos/example/configuration.nix
+++ b/configurations/nixos/example/configuration.nix
@@ -11,9 +11,6 @@
     efi.canTouchEfiVariables = true;
   };
 
-  # These are normally in hardware-configuration.nix
-  fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
-
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "example";
 

--- a/configurations/nixos/example/configuration.nix
+++ b/configurations/nixos/example/configuration.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     flake.inputs.disko.nixosModules.disko
+    ./disk-config.nix
   ];
 
   boot.loader = {

--- a/configurations/nixos/example/configuration.nix
+++ b/configurations/nixos/example/configuration.nix
@@ -1,7 +1,16 @@
 # NOTE: We expect this file to be supplanted by the original /etc/nixos/configuration.nix
+{ flake, ... }:
 {
+  imports = [
+    flake.inputs.disko.nixosModules.disko
+  ];
+
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
   # These are normally in hardware-configuration.nix
-  boot.loader.grub.device = "nodev";
   fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
 
   nixpkgs.hostPlatform = "x86_64-linux";

--- a/configurations/nixos/example/configuration.nix
+++ b/configurations/nixos/example/configuration.nix
@@ -1,15 +1,7 @@
-# NOTE: We expect this file to be supplanted by the original /etc/nixos/configuration.nix
-{ flake, ... }:
 {
   imports = [
-    flake.inputs.disko.nixosModules.disko
-    ./disk-config.nix
+    ./configuration.nix
   ];
-
-  boot.loader = {
-    systemd-boot.enable = true;
-    efi.canTouchEfiVariables = true;
-  };
 
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "example";

--- a/configurations/nixos/example/disk-config.nix
+++ b/configurations/nixos/example/disk-config.nix
@@ -1,0 +1,38 @@
+# Disko config
+{
+  disko.devices = {
+    disk = {
+      main = {
+        # When using disko-install, we will overwrite this value from the commandline
+        device = "/dev/disk/by-id/some-disk-id";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            MBR = {
+              type = "EF02"; # for grub MBR
+              size = "1M";
+            };
+            ESP = {
+              type = "EF00";
+              size = "500M";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/configurations/nixos/example/hardware-configuration.nix
+++ b/configurations/nixos/example/hardware-configuration.nix
@@ -1,0 +1,15 @@
+# This file pertains to the use of disko & disko-install.
+#
+# If you did manual NixOS install, you may want to replace this with your /etc/nixos/hardware-configuration.nix
+{ flake, ... }:
+{
+  imports = [
+    flake.inputs.disko.nixosModules.disko
+    ./disk-config.nix
+  ];
+
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741786315,
+        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -219,6 +239,7 @@
     },
     "root": {
       "inputs": {
+        "disko": "disko",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixos-unified.url = "github:srid/nixos-unified";
 
+    # NixOS specific
+    disko.url = "github:nix-community/disko";
+    disko.inputs.nixpkgs.follows = "nixpkgs";
+
     # Software inputs
     nix-index-database.url = "github:nix-community/nix-index-database";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
WIP

```
sudo nix --extra-experimental-features 'flakes nix-command' \
  run github:nix-community/disko#disko-install -- \
  --flake github:juspay/nixos-unified-template/disko#example \
  --write-efi-boot-entries \
  --disk main /dev/sda \
  --system-config '{"nixpkgs": {"hostPlatform": {"type": "override", "priority": 50, "content": "aarch64-linux"}}}'
```

(That last line is only necessary if on aarch64 linux VM)