### PR TITLE
Fix Issue #147: home-only template includes NixOS modules

### DIFF
--- a/modules/flake/template.nix
+++ b/modules/flake/template.nix
@@ -7,7 +7,7 @@
         mkDescription = name:
           "A ${name} template providing useful tools & settings for Nix-based development";
 
-        filters = path: with inputs.nixpkgs.lib; {
+        filters = path: with inputs.nixpkgs.lib; rec {
           homeOnly =
             # NOTE: configurations/home/* is imported in nix-darwin and NixOS
             hasSuffix "activate-home.nix" path;
@@ -17,6 +17,9 @@
           nixosOnly =
             hasInfix "configurations/nixos" path
             || (hasInfix "modules/nixos/" path && !hasInfix "modules/nixos/common" path);
+          homeFilter =
+              !(nixosOnly || darwinOnly) && 
+              !hasInfix "modules/nixos" path;
           alwaysExclude =
             hasSuffix "LICENSE" path
             || hasSuffix "README.md" path
@@ -53,7 +56,7 @@
             filter = path: _:
               let f = filters path;
               in
-                !(f.nixosOnly || f.darwinOnly);
+                f.homeFilter;
           };
         };
 


### PR DESCRIPTION
This PR fixes [Issue #147](https://github.com/hoarfrost32/nixos-unified-template/commit/5411fa5e23893c1c3c801280b12d364c35f2fab4).

The issue was with the attribute set returned by `filters` (in `/modules/flake/template.nix`). The `nixosOnly` filter excludes paths containing `modules/nixos/common` as an infix. However, the home template only considers paths that the `nixosOnly` or `darwinOnly` filters return false for. As a result `modules/nixos/common` was being included in the home template.

This was fixed by adding a new filter to the attribute set, `homeFilter`.